### PR TITLE
Base features

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ While this *can* be accomplished with `binary.Read`, I still have the issue of t
 * I'd like to be able to declare dynamic behavior, like when the size of the next read is determined by the current field.
 * I'd like to declare a read loop based on a read field value, and pass the loop construct to a larger pipeline.
 * ~~Struct tag field binding would be fantastic, but reflection is... fraught. I'll see how this goes, and I'll probably take some hints from how the stdlib is handling this.~~
-  * There's too much possibility of dynamic logic with a lot of binary payloads, and the number of edge cases for implementing this is more than I want to deal with.
+  * There's too much possibility of dynamic or dependent logic with a lot of binary payloads, and the number of edge cases for implementing this is more than I want to deal with.
   * I'm pretty happy with the API for mapping definition so far, and I'd rather simplify that than get into reflection with struct field tags. I feel like it's much more understandable (and thus maintainable) code.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Binscan
+# Binmap
 I've found that using the stdlib `binary` interface to read and write data is a little cumbersome and tedious, since any operation can result in an error.
 While this makes sense given the problem domain, the API leaves something to be desired.
 
-I'd love to have a way to batch operations so I don't have so much `if err != nil`.
+I'd love to have a way to batch operations, so I don't have so much `if err != nil`.
 If an error occurs at any point, then I'm able to handle one error at the end.
 
 I'd also like to work easily with `io.Reader`s rather than having to read everything into memory first.
-While this *can* be accomplished with `binary.Read`, I still have the issue of too much error handling.
+While this *can* be accomplished with `binary.Read`, I still have the issue of too much error handling cluttering normal code.
 
 ## Goals
 * I'd like to have an easier to use interface for reading/writing binary data.
@@ -14,4 +14,6 @@ While this *can* be accomplished with `binary.Read`, I still have the issue of t
 * I'd like to be able to reuse binary IO operations, and even pass them into more complex pipelines.
 * I'd like to be able to declare dynamic behavior, like when the size of the next read is determined by the current field.
 * I'd like to declare a read loop based on a read field value, and pass the loop construct to a larger pipeline.
-* Struct field binding would be fantastic, but reflection is... fraught. I'll see how this goes, and I'll probably take some hints from how the stdlib is handling this.
+* ~~Struct tag field binding would be fantastic, but reflection is... fraught. I'll see how this goes, and I'll probably take some hints from how the stdlib is handling this.~~
+  * There's too much possibility of dynamic logic with a lot of binary payloads, and the number of edge cases for implementing this is more than I want to deal with.
+  * I'm pretty happy with the API for mapping definition so far, and I'd rather simplify that than get into reflection with struct field tags. I feel like it's much more understandable (and thus maintainable) code.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
-module github.com/saylorsolutions/binscan
+module github.com/saylorsolutions/binmap
 
 go 1.19
+
+require github.com/stretchr/testify v1.8.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/subjects.go
+++ b/subjects.go
@@ -1,0 +1,385 @@
+package bin
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+)
+
+var (
+	ErrNilReadWrite = errors.New("nil read source or write target")
+)
+
+// ReadFunc is a function that reads data from a binary source.
+type ReadFunc func(r io.Reader, endian binary.ByteOrder) error
+
+func (f ReadFunc) Then(then ReadFunc) ReadFunc {
+	return func(r io.Reader, endian binary.ByteOrder) error {
+		if err := f(r, endian); err != nil {
+			return err
+		}
+		return then(r, endian)
+	}
+}
+
+// WriteFunc is a function that writes data to a binary target.
+type WriteFunc func(w io.Writer, endian binary.ByteOrder) error
+
+func (f WriteFunc) Then(then WriteFunc) WriteFunc {
+	return func(w io.Writer, endian binary.ByteOrder) error {
+		if err := f(w, endian); err != nil {
+			return err
+		}
+		return then(w, endian)
+	}
+}
+
+// Mapping is any procedure that knows how to read from and write to binary data, given an endianness policy.
+type Mapping interface {
+	// Read data from a binary source.
+	Read(r io.Reader, endian binary.ByteOrder) error
+	// Write data to a binary target.
+	Write(w io.Writer, endian binary.ByteOrder) error
+}
+
+type mapping struct {
+	read  ReadFunc
+	write WriteFunc
+}
+
+// MapSequence creates a Mapping that uses each given Mapping in order.
+func MapSequence(mappings ...Mapping) Mapping {
+	return &mapping{
+		read: func(r io.Reader, endian binary.ByteOrder) error {
+			for _, m := range mappings {
+				if err := m.Read(r, endian); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		write: func(w io.Writer, endian binary.ByteOrder) error {
+			for _, m := range mappings {
+				if err := m.Write(w, endian); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func (m *mapping) Read(r io.Reader, endian binary.ByteOrder) error {
+	if m.read != nil {
+		return m.read(r, endian)
+	}
+	return errors.New("unimplemented")
+}
+
+func (m *mapping) Write(w io.Writer, endian binary.ByteOrder) error {
+	if m.write != nil {
+		return m.write(w, endian)
+	}
+	return errors.New("unimplemented")
+}
+
+var nilMapping = &mapping{
+	read: func(r io.Reader, endian binary.ByteOrder) error {
+		return ErrNilReadWrite
+	},
+	write: func(w io.Writer, endian binary.ByteOrder) error {
+		return ErrNilReadWrite
+	},
+}
+
+// Any is provided to make it easy to create a custom Mapping for any given type.
+func Any[T any](target *T, read ReadFunc, write WriteFunc) Mapping {
+	if target == nil {
+		return nilMapping
+	}
+	return &mapping{
+		read:  read,
+		write: write,
+	}
+}
+
+// Byte will map a single byte.
+func Byte(b *byte) Mapping {
+	if b == nil {
+		return nilMapping
+	}
+	return &mapping{
+		read: func(r io.Reader, endian binary.ByteOrder) error {
+			return binary.Read(r, endian, b)
+		},
+		write: func(w io.Writer, endian binary.ByteOrder) error {
+			return binary.Write(w, endian, b)
+		},
+	}
+}
+
+// Bool will map a single boolean.
+func Bool(b *bool) Mapping {
+	if b == nil {
+		return nilMapping
+	}
+	return &mapping{
+		read: func(r io.Reader, endian binary.ByteOrder) error {
+			return binary.Read(r, endian, b)
+		},
+		write: func(w io.Writer, endian binary.ByteOrder) error {
+			return binary.Write(w, endian, b)
+		},
+	}
+}
+
+type AnyInt interface {
+	int8 | int16 | int32 | int64 | uint8 | uint16 | uint32 | uint64
+}
+
+// Int will map any integer, excluding int.
+func Int[T AnyInt](i *T) Mapping {
+	if i == nil {
+		return nilMapping
+	}
+	return &mapping{
+		read: func(r io.Reader, endian binary.ByteOrder) error {
+			return binary.Read(r, endian, i)
+		},
+		write: func(w io.Writer, endian binary.ByteOrder) error {
+			return binary.Write(w, endian, i)
+		},
+	}
+}
+
+type AnyFloat interface {
+	float32 | float64
+}
+
+// Float will map any floating point value.
+func Float[T AnyFloat](f *T) Mapping {
+	if f == nil {
+		return nilMapping
+	}
+	return &mapping{
+		read: func(r io.Reader, endian binary.ByteOrder) error {
+			return binary.Read(r, endian, f)
+		},
+		write: func(w io.Writer, endian binary.ByteOrder) error {
+			return binary.Write(w, endian, f)
+		},
+	}
+}
+
+// FixedString will map a string with a max length that is known ahead of time.
+// The target string will not contain any zero bytes if the encoded string is less than the space allowed.
+func FixedString(s *string, length int) Mapping {
+	if s == nil {
+		return nilMapping
+	}
+	return &mapping{
+		read: func(r io.Reader, endian binary.ByteOrder) error {
+			buf := make([]byte, length)
+			if err := binary.Read(r, endian, buf); err != nil {
+				return err
+			}
+			*s = string(buf)
+			return nil
+		},
+		write: func(w io.Writer, endian binary.ByteOrder) error {
+			bs := make([]byte, length)
+			copy(bs, *s)
+			return binary.Write(w, endian, bs)
+		},
+	}
+}
+
+// NullTermString will read and write null-byte terminated string.
+// The string provided doesn't have to contain a null terminator, since one will be added on write.
+func NullTermString(s *string) Mapping {
+	if s == nil {
+		return nilMapping
+	}
+	return &mapping{
+		read: func(r io.Reader, endian binary.ByteOrder) error {
+			var (
+				buf bytes.Buffer
+				br  = bufio.NewReader(r)
+			)
+			for {
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b == 0 {
+					*s = buf.String()
+					return nil
+				}
+				if err := buf.WriteByte(b); err != nil {
+					return err
+				}
+			}
+		},
+		write: func(w io.Writer, endian binary.ByteOrder) error {
+			bs := []byte(*s)
+			if err := binary.Write(w, endian, bs); err != nil {
+				return err
+			}
+			var null byte
+			return binary.Write(w, endian, &null)
+		},
+	}
+}
+
+type SizeType interface {
+	uint8 | uint16 | uint32 | uint64
+}
+
+// Size maps any value that can reasonably be used to express a size.
+func Size[S SizeType](size *S) Mapping {
+	if size == nil {
+		return nilMapping
+	}
+	return &mapping{
+		read: func(r io.Reader, endian binary.ByteOrder) error {
+			return binary.Read(r, endian, size)
+		},
+		write: func(w io.Writer, endian binary.ByteOrder) error {
+			return binary.Write(w, endian, size)
+		},
+	}
+}
+
+// FixedBytes maps a byte slice of a known length.
+func FixedBytes[S SizeType](buf *[]byte, length S) Mapping {
+	if buf == nil {
+		return nilMapping
+	}
+	sz := uint64(length)
+	return &mapping{
+		read: func(r io.Reader, endian binary.ByteOrder) error {
+			_buf := make([]byte, sz)
+			if err := binary.Read(r, endian, _buf); err != nil {
+				return err
+			}
+			*buf = _buf
+			return nil
+		},
+		write: func(w io.Writer, endian binary.ByteOrder) error {
+			out := make([]byte, sz)
+			copy(out, *buf)
+			return binary.Write(w, endian, out)
+		},
+	}
+}
+
+// LenBytes is used for situations where an arbitrarily sized byte slice is encoded after its length.
+// This mapping will read the length, and then length number of bytes into a byte slice.
+// The mapping will write the length and bytes in the same order.
+func LenBytes[S SizeType](buf *[]byte, length *S) Mapping {
+	if buf == nil {
+		return nilMapping
+	}
+	if length == nil {
+		return nilMapping
+	}
+	return &mapping{
+		read: func(r io.Reader, endian binary.ByteOrder) error {
+			if err := Size(length).Read(r, endian); err != nil {
+				return err
+			}
+			return FixedBytes(buf, *length).Read(r, endian)
+		},
+		write: func(w io.Writer, endian binary.ByteOrder) error {
+			if err := Size(length).Write(w, endian); err != nil {
+				return err
+			}
+			return FixedBytes(buf, *length).Write(w, endian)
+		},
+	}
+}
+
+// Slice will produce a mapping informed from the given functions to use a slice of values.
+// The slice length must be known ahead of time.
+// The allocNext function will be used to create an initialized value of type E, and may be used to set default values.
+// The mapVal function will be used to create a Mapping that relates to the type returned from allocNext.
+// The returned Mapping will orchestrate the array construction according to the given functions.
+func Slice[E any, S SizeType](target *[]E, count S, allocNext func() E, mapVal func(*E) Mapping) Mapping {
+	if target == nil {
+		return nilMapping
+	}
+	return &mapping{
+		read: func(r io.Reader, endian binary.ByteOrder) error {
+			input := make([]E, count)
+			i := S(0)
+			for i < count {
+				e := allocNext()
+				m := mapVal(&e)
+				if err := m.Read(r, endian); err != nil {
+					return err
+				}
+				input[i] = e
+				i++
+			}
+			*target = input
+			return nil
+		},
+		write: func(w io.Writer, endian binary.ByteOrder) error {
+			output := make([]E, count)
+			copy(output, *target)
+			for _, out := range output {
+				if err := mapVal(&out).Write(w, endian); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+}
+
+// LenSlice is for situations where a slice is encoded with its length prepended.
+// Otherwise, this behaves exactly like Slice.
+func LenSlice[E any, S SizeType](target *[]E, count *S, allocNext func() E, mapVal func(*E) Mapping) Mapping {
+	if target == nil {
+		return nilMapping
+	}
+	if count == nil {
+		return nilMapping
+	}
+	return &mapping{
+		read: func(r io.Reader, endian binary.ByteOrder) error {
+			if err := Size(count).Read(r, endian); err != nil {
+				return err
+			}
+			return Slice(target, *count, allocNext, mapVal).Read(r, endian)
+		},
+		write: func(w io.Writer, endian binary.ByteOrder) error {
+			if err := Size(count).Write(w, endian); err != nil {
+				return err
+			}
+			return Slice(target, *count, allocNext, mapVal).Write(w, endian)
+		},
+	}
+}
+
+// DynamicSlice tries to accomplish a happy medium between LenSlice and Slice.
+// A uint32 will be used to store the size of the given slice, but it's not necessary to read this from a field, rather it will be discovered at write time.
+// This means that the size will be available at read time by first reading the uint32 with LenSlice, without requiring a caller provided field.
+// In a scenario where a slice in a struct is used, this makes it easier to read and write because the struct doesn't need to store the size in a field.
+func DynamicSlice[E any](target *[]E, allocNext func() E, mapVal func(*E) Mapping) Mapping {
+	if target == nil {
+		return nilMapping
+	}
+	return &mapping{
+		read: func(r io.Reader, endian binary.ByteOrder) error {
+			var length uint32
+			return LenSlice(target, &length, allocNext, mapVal).Read(r, endian)
+		},
+		write: func(w io.Writer, endian binary.ByteOrder) error {
+			var length = uint32(len(*target))
+			return LenSlice(target, &length, allocNext, mapVal).Write(w, endian)
+		},
+	}
+}

--- a/subjects_test.go
+++ b/subjects_test.go
@@ -1,0 +1,187 @@
+package bin
+
+import (
+	"bytes"
+	"encoding/binary"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestAny(t *testing.T) {
+	test := struct {
+		a int16
+		b uint64
+	}{
+		a: -5,
+		b: 27,
+	}
+	seq := MapSequence(Int(&test.a), Int(&test.b))
+	m := Any(&test, seq.Read, seq.Write)
+
+	var (
+		buf bytes.Buffer
+	)
+	assert.NoError(t, m.Write(&buf, binary.BigEndian))
+	test.a, test.b = 0, 0
+	assert.NoError(t, m.Read(&buf, binary.BigEndian))
+	assert.Equal(t, int16(-5), test.a)
+	assert.Equal(t, uint64(27), test.b)
+}
+
+func TestByte(t *testing.T) {
+	var (
+		buf bytes.Buffer
+		a   byte
+		b   byte
+	)
+	buf.Write([]byte{0x01, 0x02})
+	m := MapSequence(Byte(&a), Byte(&b))
+	assert.NoError(t, m.Read(&buf, binary.BigEndian))
+	assert.Equal(t, byte(0x01), a)
+	assert.Equal(t, byte(0x02), b)
+
+	a, b = b, a
+	buf.Reset()
+	assert.NoError(t, m.Write(&buf, binary.BigEndian))
+	assert.Equal(t, []byte{0x02, 0x01}, buf.Bytes())
+}
+
+func TestBool(t *testing.T) {
+	var (
+		buf bytes.Buffer
+		a   bool
+		b   bool
+	)
+	buf.Write([]byte{0x01, 0x01})
+	m := MapSequence(Bool(&a), Bool(&b))
+	assert.NoError(t, m.Read(&buf, binary.BigEndian))
+	assert.Equal(t, true, a)
+	assert.Equal(t, true, b)
+
+	a, b = false, false
+	buf.Reset()
+	assert.NoError(t, m.Write(&buf, binary.BigEndian))
+	assert.Equal(t, []byte{0x00, 0x00}, buf.Bytes())
+}
+
+func TestFloat(t *testing.T) {
+	var (
+		buf    bytes.Buffer
+		endian = binary.LittleEndian
+	)
+	f1 := float32(0.5)
+	f2 := 1.5
+	m := MapSequence(Float(&f1), Float(&f2))
+	assert.NoError(t, m.Write(&buf, endian))
+
+	f1, f2 = 0, 0
+	assert.NoError(t, m.Read(&buf, endian))
+	assert.Equal(t, float32(0.5), f1)
+	assert.Equal(t, 1.5, f2)
+}
+
+func TestFixedString(t *testing.T) {
+	const (
+		expected = "Hi"
+	)
+	var (
+		buf    bytes.Buffer
+		endian = binary.BigEndian
+	)
+	s := expected
+	m := FixedString(&s, 5)
+	assert.NoError(t, m.Write(&buf, endian))
+	out := buf.Bytes()
+	assert.Equal(t, []byte{'H', 'i', 0, 0, 0}, out)
+
+	s = ""
+	buf.Reset()
+	buf.Write(out)
+	assert.NoError(t, m.Read(&buf, endian))
+}
+
+func TestNullTermString(t *testing.T) {
+	const (
+		expected = "Hi"
+	)
+	var (
+		buf    bytes.Buffer
+		endian = binary.BigEndian
+	)
+	s := expected
+	m := NullTermString(&s)
+	assert.NoError(t, m.Write(&buf, endian))
+	out := buf.Bytes()
+	assert.Equal(t, []byte{'H', 'i', 0}, out)
+
+	s = ""
+	buf.Reset()
+	buf.Write(out)
+	assert.NoError(t, m.Read(&buf, endian))
+}
+
+func TestLenBytes(t *testing.T) {
+	data := []byte("Hello!")
+	test := struct {
+		len  uint16
+		data []byte
+	}{
+		len:  uint16(len(data)),
+		data: data,
+	}
+	m := LenBytes(&test.data, &test.len)
+
+	var (
+		buf    bytes.Buffer
+		endian = binary.BigEndian
+	)
+	assert.NoError(t, m.Write(&buf, endian))
+	assert.Equal(t, 8, buf.Len())
+
+	test.len, test.data = 0, nil
+	assert.NoError(t, m.Read(&buf, endian))
+	assert.Equal(t, uint16(6), test.len)
+	assert.Equal(t, "Hello!", string(test.data))
+}
+
+func TestLenSlice(t *testing.T) {
+	test := struct {
+		len  uint8
+		data []byte
+	}{
+		len:  6,
+		data: []byte("Hello!"),
+	}
+	m := LenSlice(&test.data, &test.len, func() byte { return 0 }, func(r *byte) Mapping { return Byte(r) })
+
+	var (
+		buf    bytes.Buffer
+		endian = binary.BigEndian
+	)
+	assert.NoError(t, m.Write(&buf, endian))
+	test.len, test.data = 0, nil
+
+	assert.NoError(t, m.Read(&buf, endian))
+	assert.Equal(t, uint8(6), test.len)
+	assert.Equal(t, []byte("Hello!"), test.data)
+}
+
+func TestDynamicSlice(t *testing.T) {
+	data := []int16{1, -2, 3}
+	m := DynamicSlice(&data, func() int16 {
+		return 0
+	}, func(b *int16) Mapping {
+		return Int(b)
+	})
+
+	var (
+		buf    bytes.Buffer
+		endian = binary.LittleEndian
+	)
+	assert.NoError(t, m.Write(&buf, endian))
+	data = nil
+
+	assert.NoError(t, m.Read(&buf, endian))
+	assert.Len(t, data, 3)
+	assert.Equal(t, []int16{1, -2, 3}, data)
+}

--- a/subjects_test.go
+++ b/subjects_test.go
@@ -152,7 +152,7 @@ func TestLenSlice(t *testing.T) {
 		len:  6,
 		data: []byte("Hello!"),
 	}
-	m := LenSlice(&test.data, &test.len, func() byte { return 0 }, func(r *byte) Mapping { return Byte(r) })
+	m := LenSlice(&test.data, &test.len, func(r *byte) Mapping { return Byte(r) })
 
 	var (
 		buf    bytes.Buffer
@@ -168,9 +168,7 @@ func TestLenSlice(t *testing.T) {
 
 func TestDynamicSlice(t *testing.T) {
 	data := []int16{1, -2, 3}
-	m := DynamicSlice(&data, func() int16 {
-		return 0
-	}, func(b *int16) Mapping {
+	m := DynamicSlice(&data, func(b *int16) Mapping {
 		return Int(b)
 	})
 

--- a/subjects_test.go
+++ b/subjects_test.go
@@ -152,7 +152,7 @@ func TestLenSlice(t *testing.T) {
 		len:  6,
 		data: []byte("Hello!"),
 	}
-	m := LenSlice(&test.data, &test.len, func(r *byte) Mapping { return Byte(r) })
+	m := LenSlice(&test.data, &test.len, func(r *byte) Mapper { return Byte(r) })
 
 	var (
 		buf    bytes.Buffer
@@ -168,7 +168,7 @@ func TestLenSlice(t *testing.T) {
 
 func TestDynamicSlice(t *testing.T) {
 	data := []int16{1, -2, 3}
-	m := DynamicSlice(&data, func(b *int16) Mapping {
+	m := DynamicSlice(&data, func(b *int16) Mapper {
 		return Int(b)
 	})
 


### PR DESCRIPTION
Adding mapping functions in place of the original "pipeline" idea that first came to me. Not only is this less verbose, but it's also easier to use and more extensible. It also requires defining both read and write operations for any type, so they shouldn't get out of sync.

Generics really came in handy here, because it allowed me to group like data operations together that `binary.Read` and `binary.Write` support and discover from `any`s.

Notably absent from these functions is plain `int` and `uint`. I believe this isn't supported by the binary package functions because these types can have different sizes depending on the system "int size." At least, that rings a bell from back in the C days. Regardless, this isn't much of a constraint given the problem domain.